### PR TITLE
Dont add slow motion in edit mode

### DIFF
--- a/src/bin/Wheeler/Wheeler.cpp
+++ b/src/bin/Wheeler/Wheeler.cpp
@@ -230,7 +230,7 @@ void Wheeler::TryCloseWheeler()
 		CloseWheeler();  // close directly
 	} else {
 		// set timescale to 1 prior to closing the wheel to avoid weirdness
-		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !Wheeler::IsInEditMode()) {
+		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !_editMode) {
 			if (Utils::Time::GGTM() != 1) {
 				Utils::Time::SGTM(1);
 			}
@@ -279,7 +279,7 @@ void Wheeler::OpenWheeler()
 	}
 	
 	if (_state != WheelState::KOpened && _state != WheelState::KOpening) {
-		if (Config::Styling::Wheel::SlowTimeScale < 1 && !Wheeler::IsInEditMode()) {
+		if (Config::Styling::Wheel::SlowTimeScale < 1 && !_editMode) {
 			if (Utils::Time::GGTM() == 1) {
 				Utils::Time::SGTM(Config::Styling::Wheel::SlowTimeScale);
 			}
@@ -303,7 +303,7 @@ void Wheeler::CloseWheeler()
 		return;
 	}
 	if (_state != WheelState::KClosed) {
-		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !Wheeler::IsInEditMode()) {
+		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !_editMode) {
 			if (Utils::Time::GGTM() != 1) {
 				Utils::Time::SGTM(1);
 			}

--- a/src/bin/Wheeler/Wheeler.cpp
+++ b/src/bin/Wheeler/Wheeler.cpp
@@ -230,7 +230,7 @@ void Wheeler::TryCloseWheeler()
 		CloseWheeler();  // close directly
 	} else {
 		// set timescale to 1 prior to closing the wheel to avoid weirdness
-		if (Config::Styling::Wheel::SlowTimeScale <= 1) {
+		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !Wheeler::IsInEditMode()) {
 			if (Utils::Time::GGTM() != 1) {
 				Utils::Time::SGTM(1);
 			}
@@ -279,7 +279,7 @@ void Wheeler::OpenWheeler()
 	}
 	
 	if (_state != WheelState::KOpened && _state != WheelState::KOpening) {
-		if (Config::Styling::Wheel::SlowTimeScale < 1) {
+		if (Config::Styling::Wheel::SlowTimeScale < 1 && !Wheeler::IsInEditMode()) {
 			if (Utils::Time::GGTM() == 1) {
 				Utils::Time::SGTM(Config::Styling::Wheel::SlowTimeScale);
 			}
@@ -303,7 +303,7 @@ void Wheeler::CloseWheeler()
 		return;
 	}
 	if (_state != WheelState::KClosed) {
-		if (Config::Styling::Wheel::SlowTimeScale <= 1) {
+		if (Config::Styling::Wheel::SlowTimeScale <= 1 && !Wheeler::IsInEditMode()) {
 			if (Utils::Time::GGTM() != 1) {
 				Utils::Time::SGTM(1);
 			}


### PR DESCRIPTION
Change how slow motion work in edit mode in order to be compatible with [Skyrim Souls RE](https://www.nexusmods.com/skyrimspecialedition/mods/27859).

When these two mods are used together this happens:

* Open Inventory/Magic menu, Skyrim Souls will slow down the time.
* Opening the wheel will override the slow down time with its own time setting.
* Closing the wheel will change the time to normal time, while the user is still in the menu!!

By not changing the time in edit mode the mod is compatible with Skyrim Souls. Also this has no effect if the user is not running Skyrim Souls.