### PR TITLE
Bug fix: Shout-type items could not be inserted into the item slot.

### DIFF
--- a/src/bin/Wheeler/WheelEntry.cpp
+++ b/src/bin/Wheeler/WheelEntry.cpp
@@ -4,7 +4,7 @@
 #include "WheelItems/WheelItemFactory.h"
 #include "WheelItems/WheelItemMutable.h"
 #include "WheelEntry.h"
-
+#include "WheelItems/WheelItemShout.h"
 void WheelEntry::UpdateAnimation(RE::TESObjectREFR::InventoryItemMap& imap, float innerSpacingRad, float entryInnerAngleMin, float entryInnerAngleMax, float entryOuterAngleMin, float entryOuterAngleMax, bool hovered)
 {
 	using namespace Config::Styling::Wheel;
@@ -159,6 +159,10 @@ void WheelEntry::drawSlot(ImVec2 a_center, bool a_hovered, RE::TESObjectREFR::In
 		//遍历所有的 slot，检查物品是否还在玩家库存中
 		for (int i = 0; i < _items.size(); ++i) {
 			auto item = _items[i];
+			//如果是 shout，跳过可用性检查
+			if (auto shoutItem = std::dynamic_pointer_cast<WheelItemShout>(item)) {
+				continue;  //不要删除 shout
+			}
 			if (!item->IsAvailable(a_imap)) {
 				//标记删除的物品，不立即删除以防止影响遍历过程
 				_items.erase(_items.begin() + i);

--- a/src/bin/Wheeler/WheelItems/WheelItemShout.cpp
+++ b/src/bin/Wheeler/WheelItems/WheelItemShout.cpp
@@ -41,7 +41,7 @@ bool WheelItemShout::IsActive(RE::TESObjectREFR::InventoryItemMap& a_inv)
 
 bool WheelItemShout::IsAvailable(RE::TESObjectREFR::InventoryItemMap& a_inv)
 {
-	return false;
+	return true;
 }
 
 //TODO: check if shout's been unlocked, block equipment if not unlocked.


### PR DESCRIPTION
Added `#include "WheelItems/WheelItemShout.h"` in `WheelEntry.cpp`. In the `WheelEntry::drawSlot` function, added a check for `WheelItemShout` items. If the item is of type `shout`, it skips the availability check and is not removed from the item list. In `WheelItemShout.cpp`, changed the return value of `WheelItemShout::IsAvailable` from `false` to `true`, ensuring shout-type items are always available.

