### PR TITLE
Add Polish glyph range

### DIFF
--- a/src/bin/Rendering/FontLoader.h
+++ b/src/bin/Rendering/FontLoader.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <imgui.h>
+#include "imgui_internal.h"
+
+namespace FontLoader
+{
+    // Returns glyph ranges including Polish letters
+    static const ImWchar* GetGlyphRangesPolish()
+    {
+        static ImVector<ImWchar> ranges;
+        if (ranges.empty())
+        {
+            ImFontGlyphRangesBuilder builder;
+            builder.AddRanges(ImGui::GetIO().Fonts->GetGlyphRangesDefault());
+
+            // Polish letters
+            const ImWchar polish_chars[] = {
+                0x0104, 0x0105, // Ą ą
+                0x0106, 0x0107, // Ć ć
+                0x0118, 0x0119, // Ę ę
+                0x0141, 0x0142, // Ł ł
+                0x0143, 0x0144, // Ń ń
+                0x00D3, 0x00F3, // Ó ó
+                0x015A, 0x015B, // Ś ś
+                0x0179, 0x017A, // Ź ź
+                0x017B, 0x017C, // Ż ż
+                0
+            };
+
+            for (int i = 0; polish_chars[i]; i++) {
+                builder.AddChar(polish_chars[i]);
+            }
+
+            builder.BuildRanges(&ranges);
+        }
+        return ranges.Data;
+    }
+}

--- a/src/bin/Rendering/RenderManager.cpp
+++ b/src/bin/Rendering/RenderManager.cpp
@@ -1,4 +1,5 @@
 #include "RenderManager.h"
+#include "FontLoader.h"
 
 #include <d3d11.h>
 
@@ -29,7 +30,6 @@ namespace stl
 		T::func = trampoline.write_call<5>(hook.address(), T::thunk);
 	}
 }
-
 
 LRESULT RenderManager::WndProcHook::thunk(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -139,6 +139,9 @@ void RenderManager::D3DInitHook::thunk()
 				} else if (languageStr == "Cyrillic") {
 					glyphRanges = ImGui::GetIO().Fonts->GetGlyphRangesCyrillic();
 					INFO("Glyph range set to Cyrillic");
+				} else if (languageStr == "Polish") {
+					glyphRanges = FontLoader::GetGlyphRangesPolish();
+					INFO("Glyph range set to Polish");
 				}
 			} else {
 				INFO("No font found for language: {}", language);


### PR DESCRIPTION
Extended the allowed character range to include Polish diacritic letters:
ą, ć, ę, ł, ń, ó, ś, ź, ż.

This ensures proper handling of Polish text.
Until now, Polish characters were displayed as "?" instead.
